### PR TITLE
removed packagecloud el/5

### DIFF
--- a/script/packagecloud-push.rb
+++ b/script/packagecloud-push.rb
@@ -25,9 +25,6 @@ $client = Packagecloud::Client.new(credentials)
 # matches package directories built by docker to one or more packagecloud distros
 # https://packagecloud.io/docs#os_distro_version
 $distro_name_map = {
-  "centos/5" => %w(
-    el/5
-  ),
   "centos/6" => %w(
     el/6
   ),
@@ -102,7 +99,6 @@ package_files.each do |full_path|
   os, distro = case full_path
   when /debian\/7/ then ["Debian 7", "debian/wheezy"]
   when /debian\/8/ then ["Debian 8", "debian/jessie"]
-  when /centos\/5/ then ["RPM RHEL 5/CentOS 5", "el/5"]
   when /centos\/6/ then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/ then ["RPM RHEL 7/CentOS 7", "el/7"]
   end


### PR DESCRIPTION
# I am taking time off from maintaining this repo. I will not be reviewing pull requests.
# Details in https://code.openark.org/blog/mysql/reducing-my-oss-involvement-and-how-it-affects-orchestrator-gh-ost

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
