### PR TITLE
change master to master_auto_position=1, not auto_position=1

### DIFF
--- a/docs/script-samples.md
+++ b/docs/script-samples.md
@@ -326,10 +326,10 @@ $ orchestrator-client -c which-cluster-instances -alias mycluster | ccql -C ~/.m
 #### I'd like to apply changes to replication, without changing the replica's state (if it's running, I want it to keep running. If it's not running, I don't want to start replication)
 
 ```shell
-$ orchestrator-client -c restart-replica-statements -i mysql-bb00.dc1.domain.net -query "change master to auto_position=1" | jq .[] -r
+$ orchestrator-client -c restart-replica-statements -i mysql-bb00.dc1.domain.net -query "change master to maaster_auto_position=1" | jq .[] -r
 stop slave io_thread;
 stop slave sql_thread;
-change master to auto_position=1;
+change master to master_auto_position=1;
 start slave sql_thread;
 start slave io_thread;
 ```
@@ -340,14 +340,14 @@ Compare with:
 $ orchestrator-client -c stop-slave -i mysql-bb00.dc1.domain.net
 mysql-bb00.dc1.domain.net:3306
 
-$ orchestrator-client -c restart-replica-statements -i mysql-bb00.dc1.domain.net -query "change master to auto_position=1" | jq .[] -r
-change master to auto_position=1;
+$ orchestrator-client -c restart-replica-statements -i mysql-bb00.dc1.domain.net -query "change master to master_auto_position=1" | jq .[] -r
+change master to master_auto_position=1;
 ```
 
 The above just outputs statements, we need to push them back to the server:
 
 ```shell
-orchestrator-client -c restart-replica-statements -i mysql-bb00.dc1.domain.net -query "change master to auto_position=1" | jq .[] -r | mysql -h mysql-bb00.dc1.domain.net
+orchestrator-client -c restart-replica-statements -i mysql-bb00.dc1.domain.net -query "change master to master_auto_position=1" | jq .[] -r | mysql -h mysql-bb00.dc1.domain.net
 ```
 
 #### In which DC (data center) is a specific instance?


### PR DESCRIPTION
# I am taking time off from maintaining this repo. I will not be reviewing pull requests.
# Details in https://code.openark.org/blog/mysql/reducing-my-oss-involvement-and-how-it-affects-orchestrator-gh-ost

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
