### PR TITLE
Detection recovery sql thread

### DIFF
--- a/go/inst/instance_topology_dao.go
+++ b/go/inst/instance_topology_dao.go
@@ -249,8 +249,17 @@ func SetSemiSyncReplica(instanceKey *InstanceKey, enableReplica bool) (*Instance
 	return ReadTopologyInstance(instanceKey)
 }
 
+func StartSQLThreadQuick(instanceKey *InstanceKey) error {
+	cmd := `start slave sql_thread`
+	if _, err := ExecInstance(instanceKey, cmd); err != nil {
+		return log.Errorf("%+v: StartSQLThreadQuickly: '%q' failed: %+v", *instanceKey, cmd, err)
+	}
+	log.Infof("%s on %+v as part of StartSQLThreadQuickly", cmd, *instanceKey)
+	return nil
+}
+
 func RestartReplicationQuick(instanceKey *InstanceKey) error {
-	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`} {
+	for _, cmd := range []string{`stop slave io_thread`, `start slave io_thread`, `start slave sql_thread`} {
 		if _, err := ExecInstance(instanceKey, cmd); err != nil {
 			return log.Errorf("%+v: RestartReplicationQuick: '%q' failed: %+v", *instanceKey, cmd, err)
 		} else {

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1578,10 +1578,14 @@ func emergentlyRestartReplicationOnTopologyInstance(instanceKey *inst.InstanceKe
 			// with losing relay logs, then we've lost data.
 			// So, unfortunately we avoid this step in MariaDB GTID.
 			// See https://github.com/openark/orchestrator/issues/1260
+
+			// We will only start SQL thread
+			inst.StartSQLThreadQuick(instanceKey)
 			return
 		}
 
 		inst.RestartReplicationQuick(instanceKey)
+		inst.StartSQLThreadQuick(instanceKey)
 		inst.AuditOperation("emergently-restart-replication-topology-instance", instanceKey, string(analysisCode))
 	})
 }


### PR DESCRIPTION
# I am taking time off from maintaining this repo. I will not be reviewing pull requests.
# Details in https://code.openark.org/blog/mysql/reducing-my-oss-involvement-and-how-it-affects-orchestrator-gh-ost

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
